### PR TITLE
Fix SecurityEnforcer example for 0.4.1

### DIFF
--- a/learn.md
+++ b/learn.md
@@ -701,6 +701,8 @@ object SecurityEnforcer extends Middleware with MiddlewareBeforeField {
 
     if (permissions.nonEmpty)
       securityCtx.ensurePermissions(permissions)
+
+    continue
   }
 }
 {% endhighlight %}


### PR DESCRIPTION
`beforeField` now needs to return `continue` instead of `unit`.