### PR TITLE
Improve link anchor for h2 and h3 headers

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -213,14 +213,6 @@ a.link-link {
   color: #2c3e50;
 }
 
-.a-link {
-  position: relative;
-  top: -80px;
-  margin: 0;
-  padding: 0;
-  float: left;
-}
-
 a {
   color: #DC7676;
 }

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -229,8 +229,15 @@ a:hover, a:visited, a:active, a:focus {
   color: #db5e5e;
 }
 
-a.link-link:hover {
+a.link-link {
   color: #db5e5e;
+  opacity: 0;
+  transition: opacity .3s;
+}
+
+h2:hover a.link-link,
+h3:hover a.link-link {
+  opacity: 1;
 }
 
 h2 a.link-link span {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -97,14 +97,14 @@ $(function () {
 
     $(headers).each(function () {
       var topHeader = this.header
-      var topId = (topHeader.attr('id') ? topHeader : topHeader.find('.a-link')).attr('id')
-      var topListElem = $('<li><a href="#' + topId + '">' + topHeader.data("orig-text") + '</a></li>').appendTo(sidebar)
+      var topId = topHeader.attr('id')
+      var topListElem = $('<li><a href="#' + topId + '">' + topHeader.text() + '</a></li>').appendTo(sidebar)
 
       var children = $(this.children).map(function () {
         var subHeader = $(this)
-        var subId = (subHeader.attr('id') ? subHeader : subHeader.find('.a-link')).attr('id')
+        var subId = subHeader.attr('id')
 
-        return $('<li><a href="#' + subId + '">' + subHeader.data("orig-text") + '</a></li>')
+        return $('<li><a href="#' + subId + '">' + subHeader.text() + '</a></li>')
       })
 
       if (children.length > 0) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -51,15 +51,7 @@ $(function () {
     var me = $(this)
     var slug = slagify(me.text())
 
-    me.append($('<a class="link-link" href="#' + slug + '"><span class="glyphicon glyphicon-link"></span></a>').css('display', 'none'))
-
-    me.mouseenter(function () {
-      me.find('.link-link').stop().fadeIn(300)
-    })
-
-    me.mouseleave(function () {
-      me.find('.link-link').stop().fadeOut(300)
-    })
+    me.append($('<a class="link-link" href="#' + slug + '"><span class="glyphicon glyphicon-link"></span></a>'))
   })
 
   // Monkey patching! Yay! :(

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,4 @@
-// Please forgive me fo this terrible JS code...
+// Please forgive me for this terrible JS code...
 // I just was trying to do make it work as quickly as possible
 // in order to be able to concentrate more on the actual content
 $(function () {
@@ -49,14 +49,7 @@ $(function () {
 
   $("h2, h3").each(function () {
     var me = $(this)
-    var includeALink = me.parents('.main-content').size() === 0
     var slug = slagify(me.text())
-    var html = null
-
-    if (includeALink)
-      html = me.data('orig-text', me.text()).append('<a id="' + slug + '" href="#" class="a-link"></a>').html()
-    else
-      html = me.data('orig-text', me.text()).attr('id', slug).html()
 
     me.append($('<a class="link-link" href="#' + slug + '"><span class="glyphicon glyphicon-link"></span></a>').css('display', 'none'))
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -43,15 +43,9 @@ $(function () {
     $(document).resize(simpleHeaderShow)
   }
 
-  var slagify = function (text) {
-    return text.toLowerCase().replace(/[^\w \-]+/g,'').replace(/ +/g,'-')
-  }
-
   $("h2, h3").each(function () {
-    var me = $(this)
-    var slug = slagify(me.text())
-
-    me.append($('<a class="link-link" href="#' + slug + '"><span class="glyphicon glyphicon-link"></span></a>'))
+    var slug = $(this).attr("id")
+    $(this).append($('<a class="link-link" href="#' + slug + '"><span class="glyphicon glyphicon-link"></span></a>'))
   })
 
   // Monkey patching! Yay! :(


### PR DESCRIPTION
See individual commit messages for details of what they do.

Essentially, CSS hovers and transitions replace JS events, and use existing slug ID instead of computing one on the front-end, less likely to break in case of custom slug, etc.

I tested a build locally and everything worked fine, but to be fair I could not find where that `a-link` override was used so I figured it was old and unused anymore.

I believe that makes for simpler and better code, hope you like it 😃 