### PR TITLE
Fix canonical url to specify https instead of http

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,7 +9,7 @@
 
   <link rel="shortcut icon" type="image/png" href="{{"/assets/img/favicon.png" | prepend: site.baseurl}}">
 
-  <link rel="canonical" href="http://{{site.domain}}" />
+  <link rel="canonical" href="https://{{site.domain}}" />
 
   <meta name="description" content="Sangria - Scala GraphQL Implementation">
 


### PR DESCRIPTION
Now `sangria-graphql.org` has already migrated into https, we should specify `https://sangria-graphql.org` as canonical url instead of `http://sangria-graphql.org` :)