### PR TITLE
Remove dead link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -117,7 +117,6 @@ link:
   graphql: http://facebook.github.io/graphql/
   akka-http-example:
     github: https://github.com/sangria-graphql/sangria-akka-http-example
-    activator: https://www.typesafe.com/activator/template/sangria-akka-http-example
   try: http://try.sangria-graphql.org
   toolbox: http://toolbox.sangria-graphql.org
   try-relay: http://try-relay.sangria-graphql.org

--- a/getting-started.md
+++ b/getting-started.md
@@ -16,7 +16,7 @@ Here is how you can add it to your SBT project:
 libraryDependencies += "{{site.groupId}}" %% "sangria" % "{{site.version.sangria}}"
 ```
 
-You can find an example application that uses akka-http with _sangria_ here (it is also available as an [Activator template]({{site.link.akka-http-example.activator}})):
+You can find an example application that uses akka-http with _sangria_ here:
 
 [{{site.link.akka-http-example.github}}]({{site.link.akka-http-example.github}})
 

--- a/learn.md
+++ b/learn.md
@@ -20,8 +20,6 @@ You can find an example application that uses akka-http with _sangria_ here:
 
 [{{site.link.akka-http-example.github}}]({{site.link.akka-http-example.github}})
 
-It is also available as an [Activator template]({{site.link.akka-http-example.activator}}).
-
 I would also recommend that you check out [{{site.link.try}}]({{site.link.try}}).
 It is an example of a GraphQL server written with Play framework and Sangria. It also serves as a playground,
 where you can interactively execute GraphQL queries and play with some examples.


### PR DESCRIPTION
The link `https://www.typesafe.com/activator/template/sangria-akka-http-example` no longer exists